### PR TITLE
Fixed message that tells how to install dynamodb-local

### DIFF
--- a/lib/dynomite/db_config.rb
+++ b/lib/dynomite/db_config.rb
@@ -45,7 +45,7 @@ module Dynomite::DbConfig
 
       open = port_open?("127.0.0.1", 8000, 0.2)
       unless open
-        raise "You have configured your app to use DynamoDB local, but it is not running.  Please start DynamoDB local. Example: brew cask install dynamodb-local && dynamodb-local"
+        raise "You have configured your app to use DynamoDB local, but it is not running.  Please start DynamoDB local. Example: brew install --cask dynamodb-local && dynamodb-local"
       end
     end
 


### PR DESCRIPTION
I have changed messages.

before:  brew cask install dynamodb-local
after:   brew install --cask dynamodb-local

https://formulae.brew.sh/cask/dynamodb-local