### PR TITLE
fix issue where running dynamodb-local in docker-compose (where host is not localhost)

### DIFF
--- a/lib/dynomite/client.rb
+++ b/lib/dynomite/client.rb
@@ -63,7 +63,8 @@ module Dynomite
       def check_dynamodb_local!(endpoint)
         return unless endpoint
         endpoint_uri = URI.parse(endpoint)
-        return unless endpoint.port == 8000
+
+        return unless endpoint_uri.port == 8000
 
         open = port_open?(endpoint_uri.host, endpoint_uri.port, 0.2)
         unless open

--- a/lib/dynomite/client.rb
+++ b/lib/dynomite/client.rb
@@ -61,9 +61,11 @@ module Dynomite
       # for DynamoDB local to time out, about 10 seconds...
       # This wastes less of the users time.
       def check_dynamodb_local!(endpoint)
-        return unless endpoint && endpoint.include?("8000")
+        return unless endpoint
+        endpoint_uri = URI.parse(endpoint)
+        return unless endpoint.port == 8000
 
-        open = port_open?("127.0.0.1", 8000, 0.2)
+        open = port_open?(endpoint_uri.host, endpoint_uri.port, 0.2)
         unless open
           raise "You have configured your app to use DynamoDB local, but it is not running.  Please start DynamoDB local. Example: brew cask install dynamodb-local && dynamodb-local"
         end


### PR DESCRIPTION
check_dynamodb_local! is expecting host to be 127.0.0.1 but we run dynamodb-local in a docker container and run our tests from docker-compose where the endpoint might be something like http://dynamodb-local:8000. This PR fixes the check to allow any host on port 8000