### PR TITLE
Avoids eager-loading Dynomite::Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ A DynamoDB ORM that is ActiveModel compatible.
 
 ## Dynomite Docs
 
-* [Database Dynomite](https://rubyonjets.com/docs/database/dynamodb/)
+* [Database Dynomite](https://v5.docs.rubyonjets.com/docs/database/dynamodb/)

--- a/lib/dynomite/autoloader.rb
+++ b/lib/dynomite/autoloader.rb
@@ -20,6 +20,7 @@ module Dynomite
         loader.ignore("#{lib}/dynomite/migration/templates/*")
         loader.ignore("#{lib}/dynomite/reserved_words.rb")
         loader.do_not_eager_load("#{lib}/generators")
+        loader.do_not_eager_load("#{lib}/dynomite/engine.rb")
         loader.setup
       end
     end

--- a/lib/dynomite/item/query/relation.rb
+++ b/lib/dynomite/item/query/relation.rb
@@ -120,7 +120,7 @@ module Dynomite::Item::Query
         WARN: Scanning detected. It's recommended to not use scan. It can be slow.
         Scanning table: #{@source.table_name}
         Try creating a LSI or GSI index so dynomite can use query instead.
-        Docs: https://rubyonjets.com/docs/database/dynamodb/indexing/
+        Docs: https://v5.docs.rubyonjets.com/docs/database/dynamodb/indexing/
       EOL
     end
   end

--- a/lib/dynomite/item/read/find_with_event.rb
+++ b/lib/dynomite/item/read/find_with_event.rb
@@ -5,7 +5,7 @@ module Dynomite::Item::Read
     class_methods do
       def find_all_with_stream_event(event, options={})
         # For event payload structure see
-        # https://rubyonjets.com/docs/events/dynamodb/#event-payload
+        # https://v5.docs.rubyonjets.com/docs/events/dynamodb/#event-payload
         # Keys structure:
         # {
         #   "Records": [

--- a/lib/dynomite/item/typecaster.rb
+++ b/lib/dynomite/item/typecaster.rb
@@ -29,7 +29,7 @@ class Dynomite::Item
     #
     # The method also helps keep track of where we cast_to_type
     # It's only a few spots this provides an easy to search for it.
-    # See: https://rubyonjets.com/docs/database/dynamodb/model/typecasting/
+    # See: https://v5.docs.rubyonjets.com/docs/database/dynamodb/model/typecasting/
     FALSEY = [false, 'false', 'FALSE', 0, '0', 'f', 'F', 'off', 'OFF']
     def cast_to_type(type, value, on: :read)
       case type

--- a/lib/dynomite/migration/templates/create_table.rb
+++ b/lib/dynomite/migration/templates/create_table.rb
@@ -14,4 +14,4 @@ class <%= @migration_class_name %> < Dynomite::Migration
   end
 end
 
-# More examples: https://rubyonjets.com/docs/database/dynamodb/migration/
+# More examples: https://v5.docs.rubyonjets.com/docs/database/dynamodb/migration/

--- a/lib/dynomite/migration/templates/delete_table.rb
+++ b/lib/dynomite/migration/templates/delete_table.rb
@@ -4,4 +4,4 @@ class <%= @migration_class_name %> < Dynomite::Migration
   end
 end
 
-# More examples: https://rubyonjets.com/docs/database/dynamodb/migration/
+# More examples: https://v5.docs.rubyonjets.com/docs/database/dynamodb/migration/

--- a/lib/dynomite/migration/templates/update_table.rb
+++ b/lib/dynomite/migration/templates/update_table.rb
@@ -8,4 +8,4 @@ class <%= @migration_class_name %> < Dynomite::Migration
   end
 end
 
-# More examples: https://rubyonjets.com/docs/database/dynamodb/migration/
+# More examples: https://v5.docs.rubyonjets.com/docs/database/dynamodb/migration/

--- a/lib/dynomite/types.rb
+++ b/lib/dynomite/types.rb
@@ -13,7 +13,7 @@ module Dynomite
       binary_set: 'BS',
     }
 
-    # https://rubyonjets.com/docs/database/dynamodb/types/
+    # https://v5.docs.rubyonjets.com/docs/database/dynamodb/types/
     # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypeDescriptors
     def type_map(attribute_type)
       TYPE_MAP[attribute_type.to_s.downcase.to_sym] || attribute_type


### PR DESCRIPTION
This is meant to address issue #39, but I don't know if it breaks anything because I couldn't get the specs working. Here are the errors that I get when I run `rspec` with Ruby 3.3.5:

```
/Users/gregoryeveritt/.rbenv/versions/3.3.5/lib/ruby/3.3.0/json/generic_object.rb:2: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.

An error occurred while loading ./spec/dynomite/item/callbacks_spec.rb.
Failure/Error: before_initialize :initialize_hook

NoMethodError:
  undefined method `before_initialize' for class CallbacksTester
# ./spec/dynomite/item/callbacks_spec.rb:4:in `<class:CallbacksTester>'
# ./spec/dynomite/item/callbacks_spec.rb:1:in `<top (required)>'

An error occurred while loading ./spec/dynomite/migration/dsl/global_secondary_index_spec.rb.
Failure/Error: GSI = Dynomite::Migration::Dsl::GlobalSecondaryIndex

NameError:
  uninitialized constant Dynomite::Migration::Dsl::GlobalSecondaryIndex
# ./spec/dynomite/migration/dsl/global_secondary_index_spec.rb:1:in `<top (required)>'

An error occurred while loading ./spec/dynomite/migration/dsl/local_secondary_index_spec.rb.
Failure/Error: LSI = Dynomite::Migration::Dsl::LocalSecondaryIndex

NameError:
  uninitialized constant Dynomite::Migration::Dsl::LocalSecondaryIndex
# ./spec/dynomite/migration/dsl/local_secondary_index_spec.rb:1:in `<top (required)>'

Finished in 0.00003 seconds (files took 0.25716 seconds to load)
0 examples, 0 failures, 3 errors occurred outside of examples
```