### PR TITLE
Use a key condition on tables with composite key if at least partition key is present

### DIFF
--- a/lib/dynomite/item/indexes/finder.rb
+++ b/lib/dynomite/item/indexes/finder.rb
@@ -29,11 +29,7 @@ module Dynomite::Item::Indexes
     end
 
     def primary_key_found?
-      if @source.composite_key?
-        query_fields.include?(@source.partition_key_field) && query_fields.include?(@source.sort_key_field)
-      else
-        query_fields.include?(@source.partition_key_field)
-      end
+      query_fields.include?(@source.partition_key_field)
     end
 
     # It's possible to have multiple indexes with the same partition and sort key.


### PR DESCRIPTION
If a table is defined with a composite key (partition key and sort key), Dynomite reverts to doing a `scan` operation if you try to query with just the partition key. It _is_ possible to use a key condition when only the partition key is present, and it avoids an expensive scan operation.

As long as the partition key is present in the query, it seems to work fine. What am I missing here? Why the previous requirement to do a scan in this scenario?