### PR TITLE
Fix-up test suite

### DIFF
--- a/lib/dynomite/item.rb
+++ b/lib/dynomite/item.rb
@@ -2,7 +2,7 @@ require "active_model"
 require "digest"
 require "yaml"
 
-# The model is ActiveModel compatiable even though DynamoDB is a different type of database.
+# The model is ActiveModel compatible even though DynamoDB is a different type of database.
 #
 # Examples:
 #

--- a/spec/dynomite/item/callbacks_spec.rb
+++ b/spec/dynomite/item/callbacks_spec.rb
@@ -1,7 +1,7 @@
 class CallbacksTester < Dynomite::Item
   field :title
 
-  before_initialize :initialize_hook
+  after_initialize :initialize_hook
   before_create :create_hook
   before_save :save_hook
   before_update :update_hook

--- a/spec/dynomite/migration/dsl/global_secondary_index_spec.rb
+++ b/spec/dynomite/migration/dsl/global_secondary_index_spec.rb
@@ -1,4 +1,4 @@
-GSI = Dynomite::Migration::Dsl::GlobalSecondaryIndex
+GSI = Dynomite::Migration::Dsl::Index::Gsi
 
 describe GSI do
   def dsl

--- a/spec/dynomite/migration/dsl/local_secondary_index_spec.rb
+++ b/spec/dynomite/migration/dsl/local_secondary_index_spec.rb
@@ -1,4 +1,4 @@
-LSI = Dynomite::Migration::Dsl::LocalSecondaryIndex
+LSI = Dynomite::Migration::Dsl::Index::Lsi
 
 describe LSI do
   context "create index" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ ENV['AWS_SECRET_ACCESS_KEY'] = 'local'
 ENV['AWS_ACCESS_KEY_ID'] = 'local'
 Dynomite.configure do |config|
   config.endpoint = "http://localhost:8000"
+  config.log_level = :debug
 end
 
 module Helper


### PR DESCRIPTION
This PR is still a WIP ...

It seems like the tests/spec suite is egregiously out of date. I started poking at it to at least try to get the specs running again so I can add some tests for my recent PRs #42 and #43, and they do run now, albeit with lots of failures. I kinda paused here for now, because it seems like a big task.

Apparently the test suite requires the following DynamoDB tables to be created, although there is no migration or equivalent of a `db:test:prepare` task to create them. It looks like in the past there has been some attempt at mocking and stubbing the actual calls to DynamoDB although that's not actually working 100% and it's still going thru to the database.

- [dynomite_callbacks_testers](http://localhost:8001/tables/dynomite_callbacks_testers)
- [dynomite_comments](http://localhost:8001/tables/dynomite_comments)
- [dynomite_posts](http://localhost:8001/tables/dynomite_posts)
- [dynomite_query_params_testers](http://localhost:8001/tables/dynomite_query_params_testers)
- [dynomite_query_params_with_sort_key_testers](http://localhost:8001/tables/dynomite_query_params_with_sort_key_testers)

With these tables added to [dynamodb-local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) the tests do run locally.

This is in no way a criticism of @tongueroo's amazing work on this gem -- believe me I've been there too. Sometimes you just wanna get stuff working and updating the test suite is a burden. 

I would like to get the tests back on-par with reality so I can confidently make some tweaks to the gem. @tongueroo are you open to a quick chat about this soon?

